### PR TITLE
Feature/ec 17

### DIFF
--- a/backend/prisma/migrations/20250710174031_init/migration.sql
+++ b/backend/prisma/migrations/20250710174031_init/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[phone]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `User_phone_key` ON `User`(`phone`);

--- a/backend/src/application/DTO/response/authentication/Token.ts
+++ b/backend/src/application/DTO/response/authentication/Token.ts
@@ -1,3 +1,4 @@
 export interface Token {
-  token: string;
+  accessToken: string;
+  refreshToken: string;
 }

--- a/backend/src/application/services/TokenService/TokenService.ts
+++ b/backend/src/application/services/TokenService/TokenService.ts
@@ -8,20 +8,29 @@ interface JwtPayload {
   id: number;
   email: string;
   roles: Role[];
+  type: 'access' | 'refresh';
 }
 
 export class TokenService {
-  private readonly _secret: string;
-  private readonly _expiration: string;
+  private readonly _jwtSecret: string;
+  private readonly _accessExpiration: string;
+  private readonly _refreshExpiration: string;
 
   constructor() {
-    this._secret = process.env.JWT_SECRET as string;
-    this._expiration = process.env.JWT_EXPIRATION || '86400000';
+    this._jwtSecret = process.env.JWT_SECRET as string;
+    this._accessExpiration = process.env.JWT_EXPIRATION || '900';
+    this._refreshExpiration = process.env.JWT_REFRESH_EXPIRATION || '604800';
   }
 
-  generateToken(payload: JwtPayload): string {
-    return jwt.sign(payload, this._secret, {
-      expiresIn: `${Math.floor(Number(this._expiration) / 1000)}s`
+  generateAccessToken(payload: Omit<JwtPayload, 'type'>): string {
+    return jwt.sign({ ...payload, type: 'access' }, this._jwtSecret, {
+      expiresIn: `${Math.floor(Number(this._accessExpiration) / 1000)}s`
+    });
+  }
+
+  generateRefreshToken(payload: Omit<JwtPayload, 'type'>): string {
+    return jwt.sign({ ...payload, type: 'refresh' },this._jwtSecret, {
+      expiresIn: `${Math.floor(Number(this._refreshExpiration) / 1000)}s`
     });
   }
 }

--- a/backend/src/application/useCases/RefreshToken/index.ts
+++ b/backend/src/application/useCases/RefreshToken/index.ts
@@ -1,0 +1,50 @@
+import jwt from 'jsonwebtoken';
+import { TokenService } from 'application/services/TokenService/TokenService';
+import { Token } from 'application/DTO/response/authentication/Token';
+import { Role } from 'domain/entities/enum/Role';
+import { UnauthorizedAccess } from 'domain/exceptions/UnauthorizedAccessException';
+import { TokenExpiredException } from 'domain/exceptions/TokenExpiredException';
+
+interface JwtPayload {
+  id: number;
+  email: string;
+  roles: Role[];
+  type: 'access' | 'refresh';
+}
+
+export class RefreshTokenUseCase {
+  private readonly tokenService: TokenService;
+
+  constructor() {
+    this.tokenService = new TokenService();
+  }
+
+  run(refreshToken: string): Token {
+    try {
+      const decoded = jwt.verify(refreshToken, process.env.JWT_SECRET as string) as JwtPayload;
+
+      if (decoded.type !== 'refresh') {
+        throw new UnauthorizedAccess();
+      }
+
+      const payload = {
+        id: decoded.id,
+        email: decoded.email,
+        roles: decoded.roles,
+      };
+
+      const accessToken = this.tokenService.generateAccessToken(payload);
+      const newRefreshToken = this.tokenService.generateRefreshToken(payload);
+
+      return {
+        accessToken,
+        refreshToken: newRefreshToken,
+      };
+    } catch (err: any) {
+      if (err.name === 'TokenExpiredError') {
+        throw new TokenExpiredException();
+      }
+      throw new UnauthorizedAccess();
+    }
+  }
+}

--- a/backend/src/application/useCases/UserCreator/index.ts
+++ b/backend/src/application/useCases/UserCreator/index.ts
@@ -54,13 +54,19 @@ export class UserCreatorUseCase {
     }
 
     // Generated Token
-    const tokenStr = this._tokenService.generateToken({
+    const payload = {
       id: createdUser.id,
       email: createdUser.email,
-      roles: createdUser.roles
-    })
+      roles: createdUser.roles,
+    };
 
-    return { token: tokenStr };
+    const accessToken = this._tokenService.generateAccessToken(payload);
+    const refreshToken = this._tokenService.generateRefreshToken(payload);
+
+    return {
+      accessToken,
+      refreshToken,
+    };
 
   }
 }

--- a/backend/src/application/useCases/UserLogin/index.ts
+++ b/backend/src/application/useCases/UserLogin/index.ts
@@ -27,12 +27,18 @@ export class UserLoginUseCase {
       throw new BadCredentialsException();
     }
 
-    const tokenStr = this._tokenService.generateToken({
+    const payload = {
       id: user.id!,
       email: user.email,
-      roles: user.roles
-    });
+      roles: user.roles,
+    };
 
-    return { token: tokenStr };
+    const accessToken = this._tokenService.generateAccessToken(payload);
+    const refreshToken = this._tokenService.generateRefreshToken(payload);
+
+    return {
+      accessToken,
+      refreshToken,
+    }
   }
 }

--- a/backend/src/docs/auth.routes.yml
+++ b/backend/src/docs/auth.routes.yml
@@ -11,7 +11,7 @@ paths:
   /api/v1/auth/login:
     post:
       summary: Login user
-      description: Authenticate user and return JWT token
+      description: Authenticate user and return JWT tokens
       tags:
         - Authentication
       requestBody:
@@ -38,15 +38,16 @@ paths:
                   accessToken:
                     type: string
                     example: eyJhbGciOiJIUzI1NiIsInR5cCI6...
+                  refreshToken:
+                    type: string
+                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6...
         '400':
           description: Missing or invalid credentials
-
-
 
   /api/v1/auth/register:
     post:
       summary: Register user
-      description: Register a new user and return JWT token
+      description: Register a new user and return JWT tokens
       tags:
         - Authentication
       requestBody:
@@ -76,9 +77,12 @@ paths:
                   accessToken:
                     type: string
                     example: eyJhbGciOiJIUzI1NiIsInR5cCI6...
+                  refreshToken:
+                    type: string
+                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6...
         '400':
           description: Bad request - validation error
-  
+
   /api/v1/auth/logout:
     post:
       summary: Logout user
@@ -100,3 +104,45 @@ paths:
           description: Successfully logged out (No Content)
         '400':
           description: Missing or invalid token in Authorization header
+
+  /api/v1/auth/refresh-token:
+    post:
+      summary: Refresh JWT token
+      description: Generate a new access token using a valid refresh token
+      tags:
+        - Authentication
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: header
+          name: Authorization
+          description: Bearer refresh token
+          required: true
+          schema:
+            type: string
+            example: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+      responses:
+        '200':
+          description: Token refreshed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6...
+                  refreshToken:
+                    type: string
+                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6...
+        '400':
+          description: Missing or invalid refresh token
+        '401':
+          description: Unauthorized - refresh token expired or invalid
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/backend/src/infrastructure/config/authControllerFactory.ts
+++ b/backend/src/infrastructure/config/authControllerFactory.ts
@@ -6,6 +6,7 @@ import { InMemoryTokenBlacklistRepository } from 'infrastructure/implementations
 import { UserLogoutUseCase } from 'application/useCases/UserLogout';
 import { UserLoginUseCase } from 'application/useCases/UserLogin';
 import { LoginController } from 'infrastructure/driving-adapters/api-rest/controllers/authentication/LoginController';
+import { RefreshTokenController } from 'infrastructure/driving-adapters/api-rest/controllers/authentication/RefreshTokenController';
 
 export const buildAuthControllers = () => {
   const userRepository = new UserPrismaRepository(prisma);
@@ -19,5 +20,6 @@ export const buildAuthControllers = () => {
     registerController: new RegisterController(userRepository),
     logoutController: new LogoutController(userLogoutUseCase),
     loginController: new LoginController(userLoginUseCase),
+    refreshTokenController: new RefreshTokenController(),
   };
 };

--- a/backend/src/infrastructure/driving-adapters/api-rest/controllers/authentication/RefreshTokenController.ts
+++ b/backend/src/infrastructure/driving-adapters/api-rest/controllers/authentication/RefreshTokenController.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from 'express';
+import { RefreshTokenUseCase } from 'application/useCases/RefreshToken';
+
+export class RefreshTokenController {
+  private readonly refreshUseCase: RefreshTokenUseCase;
+
+  constructor() {
+    this.refreshUseCase = new RefreshTokenUseCase();
+  }
+
+  handle(req: Request, res: Response, next: NextFunction): void {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return next(new Error('Missing or invalid refresh token'));
+    }
+
+    const refreshToken = authHeader.split(' ')[1];
+
+    try {
+      const token = this.refreshUseCase.run(refreshToken);
+      res.status(200).json(token);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/backend/src/infrastructure/driving-adapters/api-rest/routes/user.routes.ts
+++ b/backend/src/infrastructure/driving-adapters/api-rest/routes/user.routes.ts
@@ -1,12 +1,16 @@
 import { Router } from 'express';
 import { buildAuthControllers } from '../../../config/authControllerFactory';
 
-const { registerController, logoutController, loginController } = buildAuthControllers();
+const { registerController, 
+        logoutController, 
+        loginController,
+        refreshTokenController, } = buildAuthControllers();
 
 const authRouter = Router();
 
 authRouter.post('/register', registerController.handle.bind(registerController));
 authRouter.post('/logout', logoutController.handle.bind(logoutController));
 authRouter.post('/login', loginController.handle.bind(loginController));
+authRouter.post('/refresh-token', refreshTokenController.handle.bind(refreshTokenController));
 
 export default authRouter;


### PR DESCRIPTION
Funcionalidad para el refresh token.

En el token service se agregó la lógica para la creación del refresh token, además, de agregar el tipo de token en el payload para poder manejar las request de manera correcta en el middlware de autenticación. 

Se modifico DTO/response/authentication/token para proporcionar el access token junto al refresh token al momento de registrarse o loguearse.

Creación del Use Case para el refresh token e implementación del controller necesario.

Se modifico el archivo en docs/ para documentar este nuevo endpoint y poder visualizarlo desde http://localhost:8082/api-docs/#/Authentication/post_api_v1_auth_refresh_token